### PR TITLE
no portrait orientation change when faceUp/Down

### DIFF
--- a/PharmaLedger Camera/PharmaLedger Camera/CameraSession.swift
+++ b/PharmaLedger Camera/PharmaLedger Camera/CameraSession.swift
@@ -301,9 +301,11 @@ import UIKit
         case .landscapeRight:
             connection.videoOrientation = .landscapeLeft
             capture_connection.videoOrientation = .landscapeLeft
-        default:
+        case .portrait, .portraitUpsideDown, .unknown:
             connection.videoOrientation = .portrait
             capture_connection.videoOrientation = .portrait
+        default: // .faceUp, .faceDown
+            break
         }
         
         guard let device = captureDevice else {


### PR DESCRIPTION
prevents video orientation switching back to portrait when in landscape and placing the smartphone above the sample.
Still, this assumes portrait at start